### PR TITLE
Cluedb serialization

### DIFF
--- a/lib-python/littleboxes/cluedb_test.py
+++ b/lib-python/littleboxes/cluedb_test.py
@@ -1,0 +1,68 @@
+'''
+Created on Feb 24, 2016
+
+@author: justinpalpant
+'''
+import unittest
+import os
+import time
+
+from littleboxes.cluedb import ClueDB
+
+ROOT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
+DATA_DIR = os.path.join(ROOT_DIR, 'data')
+DICTIONARIES_DIR = os.path.join(DATA_DIR, 'dictionaries')
+CLUES_DIR = os.path.join(DATA_DIR, 'clues')
+
+PERFORMANCE = False
+
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        self.repeat = 10
+        self.times = []
+
+    def tearDown(self):
+        print 'Test: {0}'.format(self.testname)
+        times = self.times
+        print 'Mean loading time {0} seconds'.format(sum(times)/len(times))
+
+    @unittest.skipIf(not PERFORMANCE, 'Not running performance tests')
+    def test_speed_load(self):
+        self.testname = 'Loading'
+        for _ in xrange(self.repeat):
+            with open(os.path.join(CLUES_DIR, 'clues.db'), 'r') as db:
+                start = time.time()
+                test_db = ClueDB.load(db)
+                self.times.append(time.time() - start)
+
+    @unittest.skipIf(not PERFORMANCE, 'Not running performance tests')
+    def test_speed_msgpack(self):
+        self.testname = 'MessagePack'
+        for _ in xrange(self.repeat):
+            with open(os.path.join(CLUES_DIR, 'clues_serial.mpk'), 'r') as dbdump:
+                start = time.time()
+                test_db = ClueDB.deserialize(dbdump)
+                self.times.append(time.time() - start)
+
+    def test_equality_msgpack(self):
+        self.testname = 'MessagePack equality'
+        start = time.time()
+
+        with open(os.path.join(CLUES_DIR, 'clues.db'), 'r') as db:
+            self.db = ClueDB.load(db)
+
+        with open(os.path.join(CLUES_DIR, 'clues_serial.mpk'), 'w') as dbdump:
+            self.db.serialize(dbdump)
+
+        with open(os.path.join(CLUES_DIR, 'clues_serial.mpk'), 'r') as dbdump:
+            test_db = ClueDB.deserialize(dbdump)
+
+        self.times.append(time.time() - start)
+
+        self.assertEqual(self.db, test_db)
+
+if __name__ == "__main__":
+    logging.getLogger('root').disabled = True
+    unittest.main()

--- a/lib-python/littleboxes/dictionary_test.py
+++ b/lib-python/littleboxes/dictionary_test.py
@@ -7,6 +7,7 @@ import unittest
 import logging
 import time
 import sys
+
 from littleboxes.dictionary import Dictionary, Trie
 
 performance_test = False
@@ -82,6 +83,7 @@ class TestDictionary(unittest.TestCase):
             for w in list_trie:
                 self.assertEqual(len(w), i)
 
+    @unittest.skipIf(not performance_test, 'Not running performance tests')
     def test_performance_get_words_with_length(self):
         max_length = max(len(w) for w in self.words)
         t = [0, 0]
@@ -117,6 +119,7 @@ class TestDictionary(unittest.TestCase):
                 for idx, letter in p.items():
                     self.assertEqual(w[idx], letter)
 
+    @unittest.skipIf(not performance_test, 'Not running performance tests')
     def test_performance_get_words_with_pattern(self):
         patterns = [{0: 'A', 1: 'B'}, {0: 'C', 1: 'H', 3: 'Z'}]
 
@@ -137,6 +140,7 @@ class TestDictionary(unittest.TestCase):
         self.logger.info('Pattern matching test: List comprehension, %0.4f '
                          'seconds; Dictionary, %0.4f seconds', t[0], t[1])
 
+    @unittest.skipIf(not performance_test, 'Not running performance tests')
     def test_performance_pattern_and_length(self):
         patterns = [{0: 'A', 1: 'B'}, {0: 'C', 1: 'H', 3: 'Z'}]
         lengths = [7, 8]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ puzpy==0.2.1
 py==1.4.31
 pytest==2.8.7
 wheel==0.24.0
+msgpack-python==0.4.7


### PR DESCRIPTION
Serialization and deserialization using MessagePack are several times faster than plain loading, and more disk space efficient.  Some custom serialization code is required, and that will have to be maintained if ClueDB changes, but it's worth it for the ~60% decrease in loading time.  Pickling was an option, but even cPickle was slower than MessagePack and it still required custom serialization code because pickle doesn't handle lambda expressions.
