### PR TITLE
Add simple N-gram model with Laplace smoothing

### DIFF
--- a/lib-python/littleboxes/ngram_model.py
+++ b/lib-python/littleboxes/ngram_model.py
@@ -1,0 +1,66 @@
+from collections import defaultdict
+import itertools
+
+
+class NgramModel(object):
+    '''Learn an N-gram model over the letters in @words.
+
+    OOV N-grams are modeled by Laplace smoothing with
+    the given pseudocount.
+    '''
+    def __init__(self, words, N=3, pseudocount=1):
+        self.N = N
+        self.pseudocount = 1
+        self._ngram2freq = defaultdict(dict)
+        self._oov2freq = defaultdict(lambda: 1.0 / 26)
+        self._init_freqs(words)
+        self._prefix_completion = {}
+        self._init_prefixes()
+
+    def _init_freqs(self, words):
+        end = [None] * (self.N-1)
+        ngram2counts = defaultdict(lambda: defaultdict(int))
+        for word in words:
+            augmented_word = end + list(word) + end
+            for ngram in window(augmented_word, self.N):
+                ngram2counts[ngram[:-1]][ngram[-1]] += 1
+
+        for prefix, count in ngram2counts.iteritems():
+            total = sum(count.itervalues()) + self.pseudocount*(26 - len(count))
+            self._oov2freq[prefix] = float(self.pseudocount) / total
+            for k, c in count.iteritems():
+                self._ngram2freq[prefix][k] = float(c) / total
+
+    def _init_prefixes(self):
+        for ngram, counts in self._ngram2freq.iteritems():
+            ml = max(counts.iterkeys(), key=lambda k: counts[k])
+            self._prefix_completion[ngram] = ml
+
+    def p(self, ngram):
+        '''Return N-gram probability, i.e. the probability of seeing
+        the letter ngram[-1] after ngram[:-1].
+        '''
+        if len(ngram) != self.N:
+            raise ValueError(
+                "Invalid %d-gram '%s' for %d-gram model" % (
+                    len(ngram), ngram, self.N))
+        ngram = tuple(ngram)
+        return self._ngram2freq.get(
+            ngram[:-1], {}).get(
+            ngram[-1], self._oov2freq[ngram[:-1]])
+
+    def most_likely(self, prefix):
+        '''Return most likely next letter given prefix (N-1) letters.'''
+        return self._prefix_completion[tuple(prefix)]
+
+
+def window(seq, n=2):
+    "Returns a sliding window (of width n) over data from the iterable"
+    "   s -> (s0,s1,...s[n-1]), (s1,s2,...,sn), ...                   "
+    it = iter(seq)
+    result = tuple(itertools.islice(it, n))
+    if len(result) == n:
+        yield result
+    for elem in it:
+        result = result[1:] + (elem,)
+        yield result

--- a/tests/ngram_test.py
+++ b/tests/ngram_test.py
@@ -1,0 +1,27 @@
+import unittest
+
+from littleboxes.ngram_model import NgramModel
+
+
+class TestNgramModel(unittest.TestCase):
+    WORDS = ['the', 'cat', 'in', 'the', 'hat']
+
+    def setUp(self):
+        self.model = NgramModel(self.WORDS, 3)
+
+    def test_p(self):
+        # 2 instances of T-H-E.
+        self.assertEqual(self.model.p('the'), 0.07407407407407407)
+        # 1 instance of -C-A.
+        self.assertEqual(self.model.p((None, 'c', 'a')), 0.038461538461538464)
+        # 2 instances of H-E-.
+        self.assertEqual(self.model.p(('h', 'e', None)), 0.07407407407407407)
+        # OOV -> 1 instance by smoothing.
+        self.assertEqual(self.model.p('oov'), 0.038461538461538464)
+        with self.assertRaises(ValueError):
+            self.model.p('invalid3gram')
+
+    def test_most_likely(self):
+        self.assertEqual(self.model.most_likely('th'), 'e')
+        self.assertEqual(self.model.most_likely('ca'), 't')
+        self.assertEqual(self.model.most_likely('he'), None)


### PR DESCRIPTION
Estimates, for any sequence of N letters, the probability `P( letters[-1] | letters[:-1] )`.

Public interface includes two functions:
1. `p(ngram)` -> return the N-gram probability.
2. `most_likely(prefix)` -> return the most likely next letter for a prefix of (N-1) letters.

Code will need some cleanup but it's a start for #10.
